### PR TITLE
move CI/test steps to pre-build

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,9 +9,7 @@ phases:
       - apt-get -y install awscli
       - echo Logging into ECR
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-  build:
-    commands:
-      - echo Build started on `date`
+      - echo Starting CI...
       - echo Building the CI Docker image...
       - docker build --target base -t dvp/developer-portal-backend-ci:$CODEBUILD_RESOLVED_SOURCE_VERSION .
       - docker images
@@ -19,6 +17,9 @@ phases:
       - docker run --rm --entrypoint '' -w "/home/node" -i dvp/developer-portal-backend-ci:$CODEBUILD_RESOLVED_SOURCE_VERSION npm run lint
       - echo Running CI tests
       - docker run --rm --entrypoint '' -w "/home/node" -i dvp/developer-portal-backend-ci:$CODEBUILD_RESOLVED_SOURCE_VERSION npm run test
+  build:
+    commands:
+      - echo Build started on `date`
       - docker build --target prod -t dvp/developer-portal-backend:$CODEBUILD_RESOLVED_SOURCE_VERSION .
       - docker tag dvp/developer-portal-backend:$CODEBUILD_RESOLVED_SOURCE_VERSION $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/dvp/developer-portal-backend:$CODEBUILD_RESOLVED_SOURCE_VERSION
   post_build:


### PR DESCRIPTION
According to https://docs.aws.amazon.com/codebuild/latest/userguide/view-build-details.html#view-build-details-phases if I want CI/Test to fail and not push a build I have to put them in the pre-build step