### PR TITLE
Set up test reporting

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -32,5 +32,5 @@ phases:
 reports:
   ci-test:
     files:
-      - 'test-report.xml'
+      - './test-report.xml'
     file-format: JunitXml


### PR DESCRIPTION
At the very least, we can output the report XML and we can use it for something later, even if the reports function doesnt work in govcloud.

No harm having the declarations in the buildspec.