### PR TITLE
Instead of using the bash script to do this, use the deploy command directly.

### DIFF
--- a/cicd/buildspec-release.yml
+++ b/cicd/buildspec-release.yml
@@ -28,7 +28,7 @@ phases:
     - python3 cicd/tag_containers.py -n dev-portal-backend-ci -i ${CODEBUILD_RESOLVED_SOURCE_VERSION} -r dvp/developer-portal-backend -v $(cicd/increment.sh $(hub tag|tail -1))
   build:
     commands:
-    - echo Triggering deploy...
-    - cicd/deploy_to_ecs.sh $(cicd/increment.sh $(hub tag|tail -1)) dev-portal-be dev
+    - echo Triggering deploy to dev...
+    - ecs deploy -t $(cicd/increment.sh $(hub tag|tail -1)) -e dvp-dev-dev-portal-be CHAMBER_ENV dev -e dvp-dev-dev-portal-be AWS_APP_NAME developer-portal-backend --timeout 1200 dev_dev_portal_be_cluster dvp-dev-dev-portal-be
   post_build:
     commands:


### PR DESCRIPTION
Instead of using a bash script to run the deploy command, we will just directly run the deploy command for dev. This change is to test that the functionality of the ecs command is working and that the bash script was not causing it to fail. I can't test this change without merging the PR to master. It's possible, once this works, that I will rewrite the script to handle the proper variables, etc for environment that it looks like I need to send.