### PR TITLE
Make Docker pull images during CI build

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,7 +11,7 @@ phases:
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
       - echo Starting CI...
       - echo Building the CI Docker image...
-      - docker build --target base -t dvp/developer-portal-backend-ci:$CODEBUILD_RESOLVED_SOURCE_VERSION .
+      - docker build --pull --target base -t dvp/developer-portal-backend-ci:$CODEBUILD_RESOLVED_SOURCE_VERSION .
       - docker images
       - echo Linting...
       - docker run --rm --entrypoint '' -w "/home/node" -i dvp/developer-portal-backend-ci:$CODEBUILD_RESOLVED_SOURCE_VERSION npm run lint
@@ -21,7 +21,7 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - docker build --target prod -t dvp/developer-portal-backend:$CODEBUILD_RESOLVED_SOURCE_VERSION .
+      - docker build --pull --target prod -t dvp/developer-portal-backend:$CODEBUILD_RESOLVED_SOURCE_VERSION .
       - docker tag dvp/developer-portal-backend:$CODEBUILD_RESOLVED_SOURCE_VERSION $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/dvp/developer-portal-backend:$CODEBUILD_RESOLVED_SOURCE_VERSION
   post_build:
     commands:


### PR DESCRIPTION
This PR is part of [IN-139](https://vasdvp.atlassian.net/browse/IN-139). We need to trust the VA internal CA to reach some upstream services.

We had an issue where an environment variable added in an upstream image was not picked up in CI because it did not pull the latest version. Adding the `--pull` flag should ensure that we always have the latest changes available.