### PR TITLE
extend timeout for deploys

### DIFF
--- a/cicd/deploy_to_ecs.sh
+++ b/cicd/deploy_to_ecs.sh
@@ -30,7 +30,7 @@ do
     dev|staging)
       echo "Deploying ${TAG} of ${NAME} to ${ENV}..."
       # Deploy to each environment and set env vars
-      ecs deploy -t "${TAG}" -e "${SERVICE}" CHAMBER_ENV "${ENV}" -e "${SERVICE}" AWS_APP_NAME developer-portal-backend --timeout 600 "${CLUSTER}" "${SERVICE}"
+      ecs deploy -t "${TAG}" -e "${SERVICE}" CHAMBER_ENV "${ENV}" -e "${SERVICE}" AWS_APP_NAME developer-portal-backend --timeout 1200 "${CLUSTER}" "${SERVICE}"
       ;;
     *)
       echo "Usage: deploy-to-ecs.sh ghVersion name environment [environment...]"


### PR DESCRIPTION
Sometimes Node containers can take a while to exit properly. We will extend the timeout to 1200 seconds to wait, so we can exit with a proper return code.