### PR TITLE
Convert cert to pem in production container to test connection issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,13 @@ FROM vasdvp/lighthouse-node-application-base:node12 AS prod
 EXPOSE 9999
 WORKDIR /home/node
 ENV NODE_ENV production
+
+RUN openssl x509 \
+  -inform der \
+  -in /etc/pki/ca-trust/source/anchors/VA-Internal-S2-RCA1-v1.cer \
+  -out /home/node/va-internal.pem
+ENV NODE_EXTRA_CA_CERTS=/home/node/va-internal.pem
+
 COPY --chown=node:node --from=base /home/node/dist dist
 COPY --chown=node:node --from=base /home/node/package*.json ./
 COPY --chown=node:node --from=base /home/node/node_modules node_modules

--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,22 @@
 import * as http from 'http'
 import configureApp from './app'
+import fs from 'fs'
+
+try {
+  const extraCerts = process.env.NODE_EXTRA_CA_CERTS || ''
+  console.log(`extra ca certs: ${extraCerts}`)
+
+  if(extraCerts !== '') {
+    const exists = fs.existsSync(extraCerts)
+    if (exists) {
+      console.log(`extra certs exist at path: ${extraCerts}`)
+    } else {
+      console.log(`extra certs do not exist at path ${extraCerts}`)
+    }
+  } 
+} catch (err) {
+  console.log(`error checking certs: ${err}`)
+}
 
 const app = configureApp()
 const server: http.Server = new http.Server(app)


### PR DESCRIPTION
This PR converts the existing certificate to a `.pem` so we can test whether Node can't handle other formats. It also adds some code to log about the `NODE_EXTRA_CA_CERTS` variable at server startup.