### PR TITLE
Clean up SlackService

### DIFF
--- a/services/SlackService.test.ts
+++ b/services/SlackService.test.ts
@@ -17,6 +17,9 @@ describe('SlackService', () => {
       status: 200,
       statusText: 'ok',
       headers: {},
+      data: {
+        channel: 'channel123'
+      },
     });
 
     // cast to unknown first to avoid having to reimplement all of AxiosInstance
@@ -27,7 +30,7 @@ describe('SlackService', () => {
 
     const res = await service.sendSuccessMessage(message, 'New User Application');
 
-    expect(res.status).toEqual(200);
+    expect(res.channel).toEqual('channel123');
     expect(mockPost).toHaveBeenCalledWith('/chat.postMessage', {
       channel: 'channel123',
       text: '',
@@ -45,6 +48,9 @@ describe('SlackService', () => {
       status: 200,
       statusText: 'ok',
       headers: {},
+      data: {
+        channel: 'channel123'
+      },
     });
     
     jest.spyOn(axios, 'create').mockImplementation(() => ({ post: mockPost } as unknown as AxiosInstance));
@@ -54,7 +60,7 @@ describe('SlackService', () => {
 
     const res = await service.sendFailureMessage(message, 'User Signup Failed');
 
-    expect(res.status).toEqual(200);
+    expect(res.channel).toEqual('channel123');
     expect(mockPost).toHaveBeenCalledWith('/chat.postMessage', {
       channel: 'channel123',
       text: '',

--- a/services/SlackService.ts
+++ b/services/SlackService.ts
@@ -1,5 +1,26 @@
 import axios, { AxiosResponse, AxiosInstance } from 'axios';
 
+interface SlackChatResponse {
+  ok: boolean;
+  channel: string;
+  ts: string;
+  message: {
+    text: string;
+    username: string;
+    bot_id: string;
+    attachments: SlackAttachment[];
+    type: string;
+    subtype: string;
+    ts: string;
+  };
+}
+
+interface SlackAttachment {
+  text: string;
+  id: number;
+  fallback: string;
+}
+
 export default class SlackService {
   private channelID: string;
   private client: AxiosInstance;
@@ -12,16 +33,16 @@ export default class SlackService {
     });
   }
 
-  public sendSuccessMessage(message: string, title: string): Promise<AxiosResponse> {
+  public sendSuccessMessage(message: string, title: string): Promise<SlackChatResponse> {
     return this.sendChatWithAttachment(message, 'good', title);
   }
 
-  public sendFailureMessage(message: string, title: string): Promise<AxiosResponse> {
+  public sendFailureMessage(message: string, title: string): Promise<SlackChatResponse> {
     return this.sendChatWithAttachment(message, 'danger', title);
   }
 
-  private async sendChatWithAttachment(message: string, color: string, title: string): Promise<AxiosResponse> {
-    return this.client.post('/chat.postMessage', {
+  private async sendChatWithAttachment(message: string, color: string, title: string): Promise<SlackChatResponse> {
+    const res: AxiosResponse<SlackChatResponse> = await this.client.post('/chat.postMessage', {
       channel: this.channelID,
       text: '',
       attachments: [{
@@ -31,5 +52,7 @@ export default class SlackService {
         title,
       }],
     });
+
+    return res.data;
   }
 }


### PR DESCRIPTION
This PR supports [API-136](https://vajira.max.gov/browse/API-136) It makes changes to the `SlackService`:
- Adds a SlackChatResponse type and returns that instead of the Axios wrapper