### PR TITLE
Change SlackService to use webhook instead of app

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -75,11 +75,15 @@ const configureOktaService = (): OktaService | undefined => {
 };
 
 const configureSlackService = (): SlackService | undefined => {
-  const { SLACK_TOKEN, SLACK_CHANNEL_ID } = process.env;
+  const { SLACK_WEBHOOK, SLACK_CHANNEL } = process.env;
   let client;
 
-  if (SLACK_TOKEN && SLACK_CHANNEL_ID) {
-    client = new SlackService(SLACK_CHANNEL_ID, SLACK_TOKEN);
+  if (SLACK_WEBHOOK && SLACK_CHANNEL) {
+    client = new SlackService(SLACK_WEBHOOK, {
+      channel: SLACK_CHANNEL,
+      username: 'Developer Portal',
+      icon_emoji: ':lighthouse:',
+    });
   }
 
   return client;

--- a/models/User.ts
+++ b/models/User.ts
@@ -5,7 +5,7 @@ import { ApplicationType, GovDeliveryUser, KongUser } from '../types';
 import Application from './Application';
 import logger from '../config/logger';
 import OktaService from '../services/OktaService';
-import SlackService, { SlackChatResponse } from '../services/SlackService';
+import SlackService from '../services/SlackService';
 import KongService from '../services/KongService';
 import GovDeliveryService, { EmailResponse } from '../services/GovDeliveryService';
 import { KONG_CONSUMER_APIS, OKTA_CONSUMER_APIS } from '../config/apis';
@@ -87,7 +87,7 @@ export default class User implements KongUser, GovDeliveryUser {
     }
   }
 
-  public sendSlackSuccess(client: SlackService): Promise<SlackChatResponse> {
+  public sendSlackSuccess(client: SlackService): Promise<string> {
     try {
       return client.sendSuccessMessage(
         this.toSlackString(),

--- a/services/SlackService.test.ts
+++ b/services/SlackService.test.ts
@@ -2,14 +2,18 @@ import axios, { AxiosInstance } from 'axios';
 import SlackService from './SlackService';
 
 describe('SlackService', () => {
+  const hookUrl = 'https://beacons.gondor.gov';
+  const hookConfig = {
+    channel: '#gondor-chat',
+    username: 'StewardBot',
+    icon_emoji: ':minas-tirith:'
+  };
+
   it('sends a provided bearer token', () => {
     const mockCreate = jest.spyOn(axios, 'create');
-    new SlackService('channel123', 'fakeToken');
+    new SlackService(hookUrl, hookConfig);
 
-    expect(mockCreate).toHaveBeenCalledWith({
-      baseURL: 'https://slack.com/api',
-      headers: { 'Authorization': `Bearer fakeToken` }
-    });
+    expect(mockCreate).toHaveBeenCalledWith({ baseURL: hookUrl });
   });
 
   it('sends a success message', async () => {
@@ -17,22 +21,22 @@ describe('SlackService', () => {
       status: 200,
       statusText: 'ok',
       headers: {},
-      data: {
-        channel: 'channel123'
-      },
+      data: 'ok',
     });
 
     // cast to unknown first to avoid having to reimplement all of AxiosInstance
     jest.spyOn(axios, 'create').mockImplementation(() => ({ post: mockPost } as unknown as AxiosInstance));
 
-    const message = "Test, User: test@example.com\nRequested access to:\n* va_facilities\n* health\n";
-    const service = new SlackService('channel123', 'faketoken');
+    const message = "Son of Denethor, Faramir: faramir@rangers.gondor.mil\nRequested access to:\n* va_facilities\n* health\n";
+    const service = new SlackService(hookUrl, hookConfig);
 
     const res = await service.sendSuccessMessage(message, 'New User Application');
 
-    expect(res.channel).toEqual('channel123');
-    expect(mockPost).toHaveBeenCalledWith('/chat.postMessage', {
-      channel: 'channel123',
+    expect(res).toEqual('ok');
+    expect(mockPost).toHaveBeenCalledWith('', {
+      channel: hookConfig.channel,
+      username: hookConfig.username,
+      icon_emoji: hookConfig.icon_emoji,
       text: '',
       attachments: [{
         text: message,


### PR DESCRIPTION
This PR fixes [API-911](https://vajira.max.gov/browse/API-911). It changes the `SlackService` to use a webhook to send messages instead of a Slack App. The Slack App that was previously used was disabled when team remembers were removed from the workspace, and it has proven difficult to get it properly re-enabled. Workspace admins have the power, but maybe not the understanding required. 

*Note:* This feature requires having environment variable changes before being deployed. Notably, it needs `SLACK_WEBHOOK` and `SLACK_CHANNEL` to be created. The previous Slack env vars can go away.