### PR TITLE
Fix contact us apis

### DIFF
--- a/routes/ContactUs.test.ts
+++ b/routes/ContactUs.test.ts
@@ -91,10 +91,7 @@ describe('contactUsHandler', () => {
         email: 'samwise@thefellowship.org',
         organization: 'The Fellowship of the Ring',
         description: 'Need help getting to Mt. Doom',
-        apis: {
-          benefits: true,
-          facilities: true,
-        },
+        apis: ['benefits', 'facilities'],
       }
     } as Request;
 
@@ -121,13 +118,7 @@ describe('contactUsHandler', () => {
         email: 'samwise@thefellowship.org',
         organization: 'The Fellowship of the Ring',
         description: 'Need help getting to Mt. Doom',
-        apis: {
-          benefits: false,
-          facilities: true,
-          health: true,
-          vaForms: false,
-          verification: false,
-        },
+        apis: ['facilities', 'health'],
       }
     } as Request;
 

--- a/routes/ContactUs.ts
+++ b/routes/ContactUs.ts
@@ -9,15 +9,6 @@ function checkRequiredFields(submittedFields: string[]): string[] {
   });
 }
 
-function filterRelevantApis(apis: { [api: string]: boolean } | undefined): string[] | undefined {
-  if (apis) {
-    const allApis = Object.keys(apis);
-    return allApis.filter(api => apis[api]);
-  }
-
-  return apis;
-}
-
 export default function contactUsHandler(govDelivery: GovDeliveryService | undefined) {
   return async function (req: Request, res: Response, next: NextFunction): Promise<void> {
     if (!govDelivery) {
@@ -42,7 +33,7 @@ export default function contactUsHandler(govDelivery: GovDeliveryService | undef
         requester: req.body.email,
         description: req.body.description,
         organization: req.body.organization,
-        apis: filterRelevantApis(req.body.apis),
+        apis: req.body.apis,
       };
       
       await govDelivery.sendSupportEmail(supportRequest);


### PR DESCRIPTION
This PR supports [API-178](https://vajira.max.gov/browse/API-178). It fixes a misunderstanding from my previous PR about the format of the API data coming from the developer portal. I previously thought that APIs would come in the format like the following:
```
apis: {
  benefits: false,
  facilities: true,
  health: true,
  vaForms: false,
  verification: false,
}
```
This idea only seemed to be supported by looking at the following line from the original lambda: https://github.com/department-of-veterans-affairs/dvp-salesforce-contact-us-lambda/blob/6d823512049016c6afd89487ae4acdbdd42cbba7/gov-delivery.js#L18

But looking at the network requests, the developer portal actually sends apis in an array like in the following: 
```
{
  "apis":["facilities"]
}
```

By replicating the original, I receive an email with a response that lists APIs as indexes like this `APIs: 0,1,2` instead of by their names like `APIs: facilities,health,benefits`.  I'm not sure what the `apisOfConcern` line does in the original lambda in light of this new knowledge.