### PR TITLE
Add contact-us validations

### DIFF
--- a/app.test.ts
+++ b/app.test.ts
@@ -32,4 +32,18 @@ describe('App routing', () => {
       });
     });
   });
+
+  describe('/contact-us', () => {
+    it('sends a 400 response and descriptive errors if validations fail', async () => {
+      const response = await request.post('/contact-us').send({
+        email: 'samwise@thefellowship.org',
+        description: 'Need help getting to Mt. Doom',
+      });
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toEqual({
+        errors: ['"firstName" is required', '"lastName" is required']
+      });
+    });
+  });
 });

--- a/app.ts
+++ b/app.ts
@@ -11,7 +11,7 @@ import GovDeliveryService from './services/GovDeliveryService';
 import { KongConfig } from './types';
 import SlackService from './services/SlackService';
 import developerApplicationHandler, { applySchema } from './routes/DeveloperApplication';
-import contactUsHandler from './routes/ContactUs';
+import contactUsHandler, { contactSchema } from './routes/ContactUs';
 import healthCheckHandler from './routes/HealthCheck';
 
 function validationMiddleware(schema: Schema) {
@@ -163,7 +163,9 @@ export default function configureApp(): express.Application {
     validationMiddleware(applySchema), 
     developerApplicationHandler(kong, okta, dynamo, govdelivery, slack));
 
-  app.post('/contact-us', contactUsHandler(govdelivery));
+  app.post('/contact-us', 
+    validationMiddleware(contactSchema),
+    contactUsHandler(govdelivery));
 
   app.get('/health_check', healthCheckHandler(kong, okta, dynamo, govdelivery, slack));
 

--- a/routes/ContactUs.ts
+++ b/routes/ContactUs.ts
@@ -1,28 +1,21 @@
 import { Request, Response, NextFunction } from 'express';
+import Joi from '@hapi/joi';
+
 import GovDeliveryService, { SupportEmail } from '../services/GovDeliveryService';
 
-const requiredFields = ['firstName', 'lastName', 'email', 'description'];
-
-function checkRequiredFields(submittedFields: string[]): string[] {
-  return requiredFields.filter(required => {
-      return !submittedFields.includes(required);
-  });
-}
+export const contactSchema = Joi.object().keys({
+  firstName: Joi.string().required(),
+  lastName: Joi.string().required(),
+  email: Joi.string().email().required(),
+  description: Joi.string().required(),
+  organization: Joi.string(),
+  apis: Joi.array().items(Joi.string()),
+}).options({ abortEarly: false });
 
 export default function contactUsHandler(govDelivery: GovDeliveryService | undefined) {
   return async function (req: Request, res: Response, next: NextFunction): Promise<void> {
     if (!govDelivery) {
       res.status(503).json({ error: 'service not enabled'});
-      return;
-    }
-
-    const submittedFields = Object.keys(req.body);
-    const missingFields = checkRequiredFields(submittedFields);
-
-    if (missingFields.length > 0) {
-      res.status(400).json({
-        error: `Missing Required Parameter(s): ${missingFields.join(',')}`,
-      });
       return;
     }
 


### PR DESCRIPTION
This PR finishes [API-1079](https://vajira.max.gov/browse/API-1079). It adds body validation of incoming requests to the `/contact-us` route. The PR is the same in structure as #59. The only difference for this PR is that the `contactUsHandler` already had some custom logic to validate required params. This logic and associated tests have been removed in favor of their equivalents in `Joi`.