### PR TITLE
Allow empty strings on OAuth-related fields

### DIFF
--- a/routes/DeveloperApplication.test.ts
+++ b/routes/DeveloperApplication.test.ts
@@ -362,6 +362,14 @@ describe('validations', () => {
 
       expect(result.error.message).toEqual('"oAuthRedirectURI" must be a valid uri with a scheme matching the http|https pattern');
     });
+
+    it('is allowed to be an empty string', () => {
+      const payload = { ...defaultPayload, oAuthRedirectURI: '' };
+
+      const result = applySchema.validate(payload);
+
+      expect(result.error).toBe(undefined);
+    });
   });
 
   describe('oAuthApplicationType', () => {
@@ -371,6 +379,14 @@ describe('validations', () => {
       const result = applySchema.validate(payload);
 
       expect(result.error.message).toEqual('"oAuthApplicationType" must be one of [web, native]');
+    });
+
+    it('is allowed to be an empty string', () => {
+      const payload = { ...defaultPayload, oAuthApplicationType: '' };
+
+      const result = applySchema.validate(payload);
+
+      expect(result.error).toBe(undefined);
     });
   });
 

--- a/routes/DeveloperApplication.ts
+++ b/routes/DeveloperApplication.ts
@@ -34,8 +34,8 @@ export const applySchema = Joi.object().keys({
   organization: Joi.string().required(),
   description: Joi.string().allow(''),
   email: Joi.string().email().required(),
-  oAuthRedirectURI: Joi.string().uri({ scheme: ['http', 'https']}),
-  oAuthApplicationType: Joi.valid('web', 'native'),
+  oAuthRedirectURI: Joi.string().allow('').uri({ scheme: ['http', 'https']}),
+  oAuthApplicationType: Joi.allow('').valid('web', 'native'),
   termsOfService: Joi.required().valid(true),
   apis: Joi.custom(validateApiList).required(),
 }).options({ abortEarly: false });


### PR DESCRIPTION
This PR fixes [API-1401](https://vajira.max.gov/browse/API-1401). It allows empty strings for OAuth-related fields, which are submitted as empty strings by the frontend when only standard APIs are selected.