### PR TITLE
Remove report group definition

### DIFF
--- a/cicd/buildspec.yml
+++ b/cicd/buildspec.yml
@@ -29,8 +29,3 @@ phases:
       - echo Build completed on `date`
       - echo Pushing the Docker image...
       - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/dvp/developer-portal-backend:$CODEBUILD_RESOLVED_SOURCE_VERSION
-reports:
-  ci-test:
-    files:
-      - './test-report.xml'
-    file-format: JunitXml


### PR DESCRIPTION
Remove report group definition from buildspec.yml as test reporting is not supported in Gov cloud. 

Slack link for context:
https://lighthouseva.slack.com/archives/CSZN6V1CH/p1597169888425900

[Gov Cloud User Guide](https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-us.pdf)