### PR TITLE
Remove mock dependency that blocks image build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
     command: npm run watch
     depends_on:
       - kong
-      - mock
     restart: on-failure
     env_file: '.env'
 


### PR DESCRIPTION
Having the mock dependency stops the app image from being built. The other services that are based off of the developer-portal-backend image try and pull a non-existent image and the app fails to launch.

Removing the mock dependency allows docker-compose to function as normal.