### PR TITLE
Upgrade okta sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -520,9 +520,9 @@
       }
     },
     "@okta/okta-sdk-nodejs": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@okta/okta-sdk-nodejs/-/okta-sdk-nodejs-3.2.0.tgz",
-      "integrity": "sha512-eRe/59BWtozrBF9ZcF4ARBcKJ+dQrPo7CluCQU69Vn7oJ+nyl/xbxDziaYRa4kmfqQ6ok40nhLTXXcImJsKiJA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@okta/okta-sdk-nodejs/-/okta-sdk-nodejs-4.1.0.tgz",
+      "integrity": "sha512-sAM7wzzqlvwbBGz539O41Zesd4t7iVzW/PdyD/HeOG+yptDdbSw+Kdw5icsd4b5m3DKMU/OWr2lxrv6QDPiivg==",
       "requires": {
         "deep-copy": "^1.4.2",
         "flat": "^2.0.1",
@@ -2257,11 +2257,21 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
     },
     "end-of-stream": {
@@ -3319,6 +3329,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -7079,9 +7090,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz",
+      "integrity": "sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hapi/joi": "^17.1.1",
-    "@okta/okta-sdk-nodejs": "^3.2.0",
+    "@okta/okta-sdk-nodejs": "^4.1.0",
     "@sentry/node": "^5.14.2",
     "aws-sdk": "^2.640.0",
     "axios": "^0.19.2",


### PR DESCRIPTION
This PR references https://vajira.max.gov/browse/API-2235.

To complete the [OAuth Isolation - /apply](https://vajira.max.gov/browse/API-1646) ticket requires using a newer version of the okta sdk than we currently are using. Reading through the 4.0 change log: https://github.com/okta/okta-sdk-nodejs/blob/master/CHANGELOG.md#400 it doesn't look like any of the functions we are currently using were changed or altered. The specs still pass so not sure what other testing is required for this...