### PR TITLE
Re-add the SLACK_WEBHOOK for codebuild in the buildspec scripts

### DIFF
--- a/cicd/buildspec-manual-deploy.yml
+++ b/cicd/buildspec-manual-deploy.yml
@@ -16,6 +16,7 @@ env:
     DEPLOY_ENVS: "prod"
   parameter-store:
     GITHUB_TOKEN: "/dvp/devops/va_bot_github_token"
+    SLACK_WEBHOOK: "/dvp/devops/codebuild_slack_webhook"
 phases:
   pre_build:
     commands:

--- a/cicd/buildspec-release.yml
+++ b/cicd/buildspec-release.yml
@@ -16,6 +16,7 @@ env:
     AUTO_DEPLOY_ENVS: "dev staging"
   parameter-store:
     GITHUB_TOKEN: "/dvp/devops/va_bot_github_token"
+    SLACK_WEBHOOK: "/dvp/devops/codebuild_slack_webhook"
 phases:
   pre_build:
     commands:


### PR DESCRIPTION
Issue: Codebuild has stopped reporting to DSVA slack when a new version of developer-portal-backend is deployed. Stems from me removing the `SLACK_WEBHOOK` from the cicd scripts. Re-adding to fix the deploy reporting.