### PR TITLE
API-2888 - Fix codebuild failure

### DIFF
--- a/cicd/buildspec.yml
+++ b/cicd/buildspec.yml
@@ -6,7 +6,6 @@ phases:
       docker: 18
   pre_build:
     commands:
-      - apt-get -y install awscli
       - echo Logging into ECR
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
       - echo Starting CI...


### PR DESCRIPTION
Codebuild was failing on trying to manually install the `awscli` and apparently this package is already installed on the image. Thanks to @duganth-va for the pointer on what to fix!