### PR TITLE
Update Sentry configuration to point to new DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,8 @@ awslogs get -ws 30m /dvp/dvp-dev-dev-portal-be
 ```
 
 ### Sentry
-Exceptions are captured in [Sentry](http://sentry.vfs.va.gov/vets-gov/). [SOCKS proxy access](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/orientation/request-access-to-tools.md) is required to see Sentry. 
-- [developer-portal-backend-dev](http://sentry.vfs.va.gov/vets-gov/developer-portal-backend-dev/)
-- [developer-portal-backend-production](http://sentry.vfs.va.gov/vets-gov/developer-portal-backend-production/)
+Exceptions are captured in [Sentry](http://sentry.vfs.va.gov/). [SOCKS proxy access](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/orientation/request-access-to-tools.md) is required to see Sentry. 
+- [dvp-developer-portal-api](http://sentry.vfs.va.gov/vsp/dvp-developer-portal-api/). Use the "environment" dropdown at the top of the Sentry UI to toggle environment-specific error filtering.
 
 Need to modify how Sentry is configured in the application? SOCKS proxy access is required to reach our Sentry instance from your local machine. To test out error reporting in a local environment you would need to configure the Sentry client to proxy through it. It's likely easier to deploy another route that consistently throws an exception.
 

--- a/config/Sentry.ts
+++ b/config/Sentry.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/node';
 const { SENTRY_DSN, SENTRY_ENV } = process.env;
 Sentry.init({
   dsn: SENTRY_DSN,
-  environment: SENTRY_ENV
+  environment: SENTRY_ENV,
 });
 
 export default Sentry;

--- a/config/Sentry.ts
+++ b/config/Sentry.ts
@@ -1,7 +1,8 @@
 import * as Sentry from '@sentry/node';
-
+const { SENTRY_DSN, SENTRY_ENV } = process.env;
 Sentry.init({
-  dsn: process.env.SENTRY_DSN,
+  dsn: SENTRY_DSN,
+  environment: SENTRY_ENV
 });
 
 export default Sentry;


### PR DESCRIPTION
## Background 

VSP recently rolled out Sentry 10 which requires a DSN update for the applications wishing to use error tracking. 

This PR also adds support for the "environments" feature of Sentry 10 by appending an environment-specific tag to the Sentry event payload. 
