### PR TITLE
Add Docker Login to CodeBuild Project

### DIFF
--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -24,6 +24,7 @@ phases:
   pre_build:
     commands:
       - echo Logging into Docker
+      # Login to Docker Hub prior to pulling Dockerfile's base image vasdvp/lighthouse-node-application-base:node12. This prevents rate limiting.
       - echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
       - echo Starting CI...
       - echo Building the CI Docker image...
@@ -43,6 +44,7 @@ phases:
     commands:
       - docker images
       - echo Build completed on `date`
+      # Login to ECR to push build artifact.
       - echo Logging into ECR
       - aws ecr get-login-password | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
       - echo Pushing the Docker image...

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -24,7 +24,7 @@ phases:
   pre_build:
     commands:
       - echo Logging into Docker
-      - echo "${DOCKER_PASSWORD} | docker login --username ${DOCKER_USERNAME} --password-stdin
+      - echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
       - echo Starting CI...
       - echo Building the CI Docker image...
       - docker build --pull --target base -t dvp/developer-portal-backend-ci:$CODEBUILD_RESOLVED_SOURCE_VERSION .

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -10,6 +10,10 @@
 # 
 ######################################################################
 version: 0.2
+env:
+  parameter-store:
+    DOCKER_USERNAME: "/dvp/devops/DOCKER_USERNAME"
+    DOCKER_PASSWORD: "/dvp/devops/DOCKER_PASSWORD"
 phases:
   install:
     commands:
@@ -19,8 +23,8 @@ phases:
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
   pre_build:
     commands:
-      - echo Logging into ECR
-      - aws ecr get-login-password | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+      - echo Logging into Docker
+      - docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
       - echo Starting CI...
       - echo Building the CI Docker image...
       - docker build --pull --target base -t dvp/developer-portal-backend-ci:$CODEBUILD_RESOLVED_SOURCE_VERSION .
@@ -39,5 +43,7 @@ phases:
     commands:
       - docker images
       - echo Build completed on `date`
+      - echo Logging into ECR
+      - aws ecr get-login-password | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
       - echo Pushing the Docker image...
       - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/dvp/developer-portal-backend:$CODEBUILD_RESOLVED_SOURCE_VERSION

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -24,7 +24,7 @@ phases:
   pre_build:
     commands:
       - echo Logging into Docker
-      - docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
+      - docker login --username ${DOCKER_USERNAME} --password-stdin ${DOCKER_PASSWORD}
       - echo Starting CI...
       - echo Building the CI Docker image...
       - docker build --pull --target base -t dvp/developer-portal-backend-ci:$CODEBUILD_RESOLVED_SOURCE_VERSION .

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -24,7 +24,7 @@ phases:
   pre_build:
     commands:
       - echo Logging into Docker
-      - docker login --username ${DOCKER_USERNAME} --password-stdin ${DOCKER_PASSWORD}
+      - echo "${DOCKER_PASSWORD} | docker login --username ${DOCKER_USERNAME} --password-stdin
       - echo Starting CI...
       - echo Building the CI Docker image...
       - docker build --pull --target base -t dvp/developer-portal-backend-ci:$CODEBUILD_RESOLVED_SOURCE_VERSION .

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -24,7 +24,7 @@ phases:
   pre_build:
     commands:
       - echo Logging into Docker
-      # Login to Docker Hub prior to pulling Dockerfile's base image vasdvp/lighthouse-node-application-base:node12. This prevents rate limiting.
+      # Login to Docker Hub prior to pulling Dockerfile's base image vasdvp/lighthouse-node-application-base:node12. This prevents rate limiting from Docker Hub.
       - echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
       - echo Starting CI...
       - echo Building the CI Docker image...


### PR DESCRIPTION
Add authenticated login to docker hub prior to build for CodeBuild Project to prevent concerns regarding new Docker Hub rate limiting. 