### PR TITLE
Organize all routes under either a public Express router or a protected Express router to secure admin routes

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -37,7 +37,7 @@ const configureGovDeliveryService = (): GovDeliveryService => {
   return new GovDeliveryService({
     host: GOVDELIVERY_HOST,
     token: GOVDELIVERY_KEY,
-    supportEmailRecipient: SUPPORT_EMAIL || 'api@va.gov',
+    supportEmailRecipient: SUPPORT_EMAIL,
   });
 };
 

--- a/routes/ContactUs.integration.ts
+++ b/routes/ContactUs.integration.ts
@@ -7,7 +7,7 @@ import configureApp from '../app';
 const request = supertest(configureApp());
 describe.each([
   '/contact-us',
-  '/public/contact-us',
+  '/internal/developer-portal/public/contact-us',
 ])('%s', (route: string) => {
   const govDelivery = nock(`${process.env.GOVDELIVERY_HOST}`);
 

--- a/routes/ContactUs.integration.ts
+++ b/routes/ContactUs.integration.ts
@@ -5,7 +5,10 @@ import nock from 'nock';
 import configureApp from '../app';
 
 const request = supertest(configureApp());
-describe('/contact-us', () => {
+describe.each([
+  '/contact-us',
+  '/public/contact-us',
+])('%s', (route: string) => {
   const govDelivery = nock(`${process.env.GOVDELIVERY_HOST}`);
 
   const supportReq = {
@@ -18,7 +21,7 @@ describe('/contact-us', () => {
   };
 
   it('sends a 400 response and descriptive errors if validations fail', async () => {
-    const response = await request.post('/contact-us').send({
+    const response = await request.post(route).send({
       email: 'samwise@thefellowship.org',
       description: 'Need help getting to Mt. Doom',
     });
@@ -34,7 +37,7 @@ describe('/contact-us', () => {
       .post('/messages/email')
       .reply(200, { from_name: 'Samwise', from_email: 'samwise@thefellowship.org' });
 
-    const response = await request.post('/contact-us').send(supportReq);
+    const response = await request.post(route).send(supportReq);
 
     expect(response.status).toEqual(200);
   });
@@ -44,7 +47,7 @@ describe('/contact-us', () => {
       .post('/messages/email')
       .reply(500);
 
-    const response = await request.post('/contact-us').send(supportReq);
+    const response = await request.post(route).send(supportReq);
     
     expect(response.status).toEqual(500);
     expect(response.body.action).toEqual('sending contact us email');

--- a/routes/ContactUs.test.ts
+++ b/routes/ContactUs.test.ts
@@ -30,23 +30,6 @@ describe('contactUsHandler', () => {
     mockSendEmail.mockClear();
   });
 
-  it('returns a 503 if the service is not configured', async () => {
-    const handler = contactUsHandler(undefined);
-    const mockReq = {
-      body: {
-        firstName: 'Samwise',
-        lastName: 'Gamgee',
-        email: 'samwise@thefellowship.org',
-        description: 'Need help getting to Mt. Doom',
-      },
-    } as Request;
-
-    await handler(mockReq, mockRes, mockNext);
-
-    expect(mockStatus).toHaveBeenCalledWith(503);
-    expect(mockJson).toHaveBeenCalledWith({ error: 'service not enabled' });
-  });
-
   it('responds with a 200 when the request is okay', async () => {
     const handler = contactUsHandler(mockGovDelivery);
     const mockReq = {

--- a/routes/ContactUs.ts
+++ b/routes/ContactUs.ts
@@ -12,13 +12,8 @@ export const contactSchema = Joi.object().keys({
   apis: Joi.array().items(Joi.string()),
 }).options({ abortEarly: false });
 
-export default function contactUsHandler(govDelivery: GovDeliveryService | undefined) {
+export default function contactUsHandler(govDelivery: GovDeliveryService) {
   return async function (req: Request, res: Response, next: NextFunction): Promise<void> {
-    if (!govDelivery) {
-      res.status(503).json({ error: 'service not enabled'});
-      return;
-    }
-
     try {
       const supportRequest: SupportEmail = {
         firstName: req.body.firstName,

--- a/routes/DeveloperApplication.integration.ts
+++ b/routes/DeveloperApplication.integration.ts
@@ -8,7 +8,10 @@ import { oktaAuthMocks } from '../types/mocks';
 import { OKTA_AUTHZ_ENDPOINTS } from '../config/apis';
 
 const request = supertest(configureApp());
-describe('/developer_application', () => {
+describe.each([
+  '/developer_application',
+  '/public/developer_application',
+])('%s', (route: string) => {
   const kong = nock(`http://${process.env.KONG_HOST}:8000`);
   const okta = nock(process.env.OKTA_HOST);
   const dynamoDB = nock(`${process.env.DYNAMODB_ENDPOINT}`);
@@ -68,7 +71,7 @@ describe('/developer_application', () => {
   });
 
   it('sends a 400 response and descriptive errors if validations fail', async () => {
-    const response = await request.post('/developer_application').send({
+    const response = await request.post(route).send({
       apis: 'benefits',
       email: 'eowyn@rohan.horse',
       lastName: 'Eorl',
@@ -83,7 +86,7 @@ describe('/developer_application', () => {
 
   describe('200 success', () => {
     it('succeeds for a request with only key auth api', async () => {
-      const response = await request.post('/developer_application').send({
+      const response = await request.post(route).send({
         ...baseAppRequest,
         apis: 'facilities',
       });
@@ -95,7 +98,7 @@ describe('/developer_application', () => {
     });
 
     it('succeeds for a request with only oauth api', async () => {
-      const response = await request.post('/developer_application').send({
+      const response = await request.post(route).send({
         ...baseAppRequest,
         apis: 'verification',
         oAuthRedirectURI: 'https://fake-oAuth-redirect-uri',
@@ -110,7 +113,7 @@ describe('/developer_application', () => {
     });
 
     it('succeeds (with an empty response) for a request with only oauth api and an empty oAuthRedirectURI', async () => {
-      const response = await request.post('/developer_application').send({
+      const response = await request.post(route).send({
         ...baseAppRequest,
         apis: 'verification',
         oAuthRedirectURI: '',
@@ -122,7 +125,7 @@ describe('/developer_application', () => {
     });
 
     it('succeeds for a request with both key auth and oauth apis', async () => {
-      const response = await request.post('/developer_application').send(devAppRequest);
+      const response = await request.post(route).send(devAppRequest);
 
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({
@@ -144,7 +147,7 @@ describe('/developer_application', () => {
       });
 
       it('only consumer', async () => {
-        const response = await request.post('/developer_application').send(devAppRequest);
+        const response = await request.post(route).send(devAppRequest);
 
         expect(response.status).toEqual(200);
         expect(response.body).toEqual({
@@ -165,7 +168,7 @@ describe('/developer_application', () => {
           ],
         });
 
-        const response = await request.post('/developer_application').send(devAppRequest);
+        const response = await request.post(route).send(devAppRequest);
 
         expect(response.status).toEqual(200);
         expect(response.body).toEqual({
@@ -188,7 +191,7 @@ describe('/developer_application', () => {
           ],
         });
 
-        const response = await request.post('/developer_application').send(devAppRequest);
+        const response = await request.post(route).send(devAppRequest);
 
         expect(response.status).toEqual(200);
         expect(response.body).toEqual({
@@ -206,7 +209,7 @@ describe('/developer_application', () => {
 
       govDelivery.post(path).reply(500);
 
-      const response = await request.post('/developer_application').send(devAppRequest);
+      const response = await request.post(route).send(devAppRequest);
 
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({
@@ -223,7 +226,7 @@ describe('/developer_application', () => {
 
       slack.post(path).reply(500);
 
-      const response = await request.post('/developer_application').send(devAppRequest);
+      const response = await request.post(route).send(devAppRequest);
 
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({
@@ -243,7 +246,7 @@ describe('/developer_application', () => {
 
         kong.post(path).reply(500);
 
-        const response = await request.post('/developer_application').send(devAppRequest);
+        const response = await request.post(route).send(devAppRequest);
 
         expect(response.body).toEqual({
           action: 'failed creating kong consumer',
@@ -260,7 +263,7 @@ describe('/developer_application', () => {
 
         kong.post(path).reply(500);
 
-        const response = await request.post('/developer_application').send(devAppRequest);
+        const response = await request.post(route).send(devAppRequest);
 
         expect(response.body).toEqual({
           action: 'failed creating kong consumer',
@@ -277,7 +280,7 @@ describe('/developer_application', () => {
         nock.removeInterceptor(interceptor);
         kong.post(path).reply(500);
 
-        const response = await request.post('/developer_application').send(devAppRequest);
+        const response = await request.post(route).send(devAppRequest);
 
         expect(response.body).toEqual({
           action: 'failed creating kong consumer',
@@ -296,7 +299,7 @@ describe('/developer_application', () => {
 
         okta.post(path).reply(500);
 
-        const response = await request.post('/developer_application').send(devAppRequest);
+        const response = await request.post(route).send(devAppRequest);
 
         expect(response.body).toEqual({
           action: 'failed saving to okta',
@@ -313,7 +316,7 @@ describe('/developer_application', () => {
 
         okta.put(path).reply(500);
 
-        const response = await request.post('/developer_application').send(devAppRequest);
+        const response = await request.post(route).send(devAppRequest);
 
         expect(response.body).toEqual({
           action: 'failed saving to okta',
@@ -331,7 +334,7 @@ describe('/developer_application', () => {
 
         okta.get(path).reply(500);
 
-        const response = await request.post('/developer_application').send(devAppRequest);
+        const response = await request.post(route).send(devAppRequest);
 
         expect(response.body).toEqual({
           action: 'failed saving to okta',
@@ -349,7 +352,7 @@ describe('/developer_application', () => {
 
         okta.put(path).reply(500);
 
-        const response = await request.post('/developer_application').send(devAppRequest);
+        const response = await request.post(route).send(devAppRequest);
 
         expect(response.body).toEqual({
           action: 'failed saving to okta',
@@ -370,7 +373,7 @@ describe('/developer_application', () => {
         // For some reason putItem makes two calls...
         dynamoDB.post('/').reply(500).post('/').reply(500);
 
-        const response = await request.post('/developer_application').send(devAppRequest);
+        const response = await request.post(route).send(devAppRequest);
 
         expect(response.body).toEqual({
           action: 'failed saving to dynamo',

--- a/routes/DeveloperApplication.integration.ts
+++ b/routes/DeveloperApplication.integration.ts
@@ -10,7 +10,7 @@ import { OKTA_AUTHZ_ENDPOINTS } from '../config/apis';
 const request = supertest(configureApp());
 describe.each([
   '/developer_application',
-  '/public/developer_application',
+  '/internal/developer-portal/public/developer_application',
 ])('%s', (route: string) => {
   const kong = nock(`http://${process.env.KONG_HOST}:8000`);
   const okta = nock(process.env.OKTA_HOST);

--- a/routes/HealthCheck.integration.ts
+++ b/routes/HealthCheck.integration.ts
@@ -5,7 +5,10 @@ import nock from 'nock';
 import configureApp from '../app';
 
 const request = supertest(configureApp());
-describe('/health_check', () => {
+describe.each([
+  '/health_check',
+  '/public/health_check',
+])('%s', (route: string) => {
   const kong = nock(`http://${process.env.KONG_HOST}:8000`);
   const okta = nock(process.env.OKTA_HOST);
   const dynamoDB = nock(`${process.env.DYNAMODB_ENDPOINT}`);
@@ -30,7 +33,7 @@ describe('/health_check', () => {
 
   describe('vibrant', () => {
     it('sends 200 when all services report as healthy', async () => {
-      const response = await request.get('/health_check');
+      const response = await request.get(route);
 
       expect(response.body).toEqual({
         healthStatus: 'vibrant',
@@ -48,7 +51,7 @@ describe('/health_check', () => {
 
         kong.get(kongMockPath).reply(500);
 
-        const response = await request.get('/health_check');
+        const response = await request.get(route);
 
         expect(response.body).toEqual({
           healthStatus: 'lackluster',
@@ -67,7 +70,7 @@ describe('/health_check', () => {
 
         kong.get(kongMockPath).reply(200, {username: 'wrongUser'});
 
-        const response = await request.get('/health_check');
+        const response = await request.get(route);
 
         expect(response.body).toEqual({
           healthStatus: 'lackluster',
@@ -88,7 +91,7 @@ describe('/health_check', () => {
 
         okta.get(oktaMockPath).reply(500);
 
-        const response = await request.get('/health_check');
+        const response = await request.get(route);
 
         expect(response.body).toEqual({
           healthStatus: 'lackluster',
@@ -109,7 +112,7 @@ describe('/health_check', () => {
 
         dynamoDB.post(dynamoMockPath).reply(500);
 
-        const response = await request.get('/health_check');
+        const response = await request.get(route);
 
         expect(response.body).toEqual({
           healthStatus: 'lackluster',
@@ -128,7 +131,7 @@ describe('/health_check', () => {
 
         dynamoDB.post(dynamoMockPath).reply(200, '{"TableNames":[]}');
 
-        const response = await request.get('/health_check');
+        const response = await request.get(route);
 
         expect(response.body).toEqual({
           healthStatus: 'lackluster',
@@ -149,7 +152,7 @@ describe('/health_check', () => {
 
         govDelivery.post(govDeliveryMockPath).reply(500);
 
-        const response = await request.get('/health_check');
+        const response = await request.get(route);
 
         expect(response.body).toEqual({
           healthStatus: 'lackluster',
@@ -168,7 +171,7 @@ describe('/health_check', () => {
 
         govDelivery.post(govDeliveryMockPath).reply(401);
 
-        const response = await request.get('/health_check');
+        const response = await request.get(route);
 
         expect(response.body).toEqual({
           healthStatus: 'lackluster',
@@ -189,7 +192,7 @@ describe('/health_check', () => {
 
         slack.post(slackMockPath).reply(500);
 
-        const response = await request.get('/health_check');
+        const response = await request.get(route);
 
         expect(response.body).toEqual({
           healthStatus: 'lackluster',
@@ -208,7 +211,7 @@ describe('/health_check', () => {
 
         slack.post(slackMockPath).reply(200, {ok: false});
 
-        const response = await request.get('/health_check');
+        const response = await request.get(route);
 
         expect(response.body).toEqual({
           healthStatus: 'lackluster',

--- a/routes/HealthCheck.integration.ts
+++ b/routes/HealthCheck.integration.ts
@@ -7,7 +7,7 @@ import configureApp from '../app';
 const request = supertest(configureApp());
 describe.each([
   '/health_check',
-  '/public/health_check',
+  '/internal/developer-portal/public/health_check',
 ])('%s', (route: string) => {
   const kong = nock(`http://${process.env.KONG_HOST}:8000`);
   const okta = nock(process.env.OKTA_HOST);

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -1,0 +1,70 @@
+import { Schema, ValidationErrorItem } from '@hapi/joi';
+import express, { Express, Request, Response, NextFunction } from 'express';
+import DynamoService from '../services/DynamoService';
+import GovDeliveryService from '../services/GovDeliveryService';
+import KongService from '../services/KongService';
+import OktaService from '../services/OktaService';
+import SignupMetricsService from '../services/SignupMetricsService';
+import SlackService from '../services/SlackService';
+import developerApplicationHandler, { applySchema } from './DeveloperApplication';
+import contactUsHandler, { contactSchema } from './ContactUs';
+import healthCheckHandler from './HealthCheck';
+import signupsReportHandler, { signupsReportSchema } from './management/SignupsReport';
+
+export function validationMiddleware(schema: Schema, toValidate: string) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const { error } = schema.validate(req[toValidate]);
+    if (error) {
+      const messages = error.details.map((i: ValidationErrorItem) => i.message);
+      res.status(400).json({ errors: messages });
+    } else {
+      next();
+    }
+  };
+}
+
+interface AppServices {
+  kong: KongService;
+  okta: OktaService;
+  dynamo: DynamoService;
+  govDelivery: GovDeliveryService;
+  slack: SlackService;
+  signups: SignupMetricsService;
+}
+
+const configureRoutes = (app: Express, services: AppServices): void => {
+  const {
+    kong,
+    okta,
+    dynamo,
+    govDelivery,
+    signups,
+    slack,
+  } = services;
+
+  /**
+   * PUBLIC
+   */
+  const publicRoutes = express.Router();
+  publicRoutes.post('/developer_application',
+    validationMiddleware(applySchema, 'body'),
+    developerApplicationHandler(kong, okta, dynamo, govDelivery, slack));
+  
+  publicRoutes.post('/contact-us',
+    validationMiddleware(contactSchema, 'body'),
+    contactUsHandler(govDelivery));
+  
+  publicRoutes.get('/health_check', healthCheckHandler(kong, okta, dynamo, govDelivery, slack));
+  app.use('/public', publicRoutes);
+
+  /**
+   * PROTECTED
+   */
+  const adminRoutes = express.Router();
+  adminRoutes.get('/reports/signups',
+    validationMiddleware(signupsReportSchema, 'query'),
+    signupsReportHandler(signups, slack));
+  app.use('/admin', adminRoutes);
+};
+
+export default configureRoutes;

--- a/routes/management/SignupsReport.integration.ts
+++ b/routes/management/SignupsReport.integration.ts
@@ -10,7 +10,7 @@ const slack = nock(process.env.SLACK_BASE_URL);
 
 describe.each([
   '/reports/signups',
-  '/admin/reports/signups',
+  '/internal/developer-portal/admin/reports/signups',
 ])('%s', (route: string) => {
   beforeEach(() => {
     nock.cleanAll();

--- a/routes/management/SignupsReport.test.ts
+++ b/routes/management/SignupsReport.test.ts
@@ -74,15 +74,6 @@ describe('signupsReportHandler', () => {
       .mockResolvedValueOnce(largeResult);
   });
 
-  it('returns a 503 if the service is not configured', async () => {
-    const handler = signupsReportHandler(mockSignups, undefined);
-
-    await handler(mockReq, mockRes, mockNext);
-
-    expect(mockStatus).toHaveBeenCalledWith(503);
-    expect(mockJson).toHaveBeenCalledWith({ error: 'service not enabled' });
-  });
-
   it('responds with a 200 when the request is okay', async () => {
     const handler = signupsReportHandler(mockSignups, mockSlack);
 

--- a/routes/management/SignupsReport.ts
+++ b/routes/management/SignupsReport.ts
@@ -36,11 +36,6 @@ function setStartAndEndDates(reqStart: string | undefined, reqEnd: string | unde
 
 export default function signupsReportHandler(signups: SignupMetricsService, slack: SlackService) {
   return async function (req: Request, res: Response, next: NextFunction): Promise<void> {
-    if (!slack) {
-      res.status(503).json({ error: 'service not enabled' });
-      return;
-    }
-
     const span = req.query.span || 'week';
     const { start, end } = setStartAndEndDates(req.query.start, req.query.end, span);
 


### PR DESCRIPTION
### Description

in support of [API-3337](https://vajira.max.gov/browse/API-3337). re-organizes routes so that all publicly accessible routes (Apply, Contact Us, Health Check) are prefixed with `/public/` and all protected routes are prefixed with `/admin/`. the implementation is that all routes are now registered under one of two routers, one for public routes and one for protected routes.

these changes are in support of roughly the following (greatly simplified) configuration for the developer portal backend service in Kong:

```
- name: developer-portal-backend
  attributes:
    host: ${DEVELOPER_PORTAL_BACKEND_ALB}
    port: 9999
    path: /
  routes:
    - name: developer-portal-backend-management
      plugins:
        # PLUGINS FOR KEY-AUTH
        - name: key-auth
          ...
        - name: acl
          ...
        attributes:
          strip_path: false # PASS /admin TO BACKEND REQUEST
          paths:
            - /admin
    - name: developer-portal-backend
      attributes:
        strip_path: false # PASS /public TO BACKEND REQUEST
        paths:
          - /public
```

the real config is in this PR: https://github.com/department-of-veterans-affairs/devops/pull/7913.

the core point here is that `/reports/signups` should not be accessible at `/internal/developer-portal-backend/reports/signups`, which it is currently. by separating all routes into `/public` and `/admin` and clearly separating those two paths at the gateway level with `strip_path: false`, we can secure routes that should be protected and make it harder to make a similar overlap in the future.

### Notes

- temporarily adds routes to integration tests with `describe.each()` blocks. these will be reverted back to the original when the old routes are removed.
- the routes `/` and `/health` (NOT '/health_check`) have not been nested under either of the two main routers. the rationale is that neither of these routes need to be run through 
  - `/` is sort of a dummy route that never needs to be accessed through the gateway.
  - `/health` is accessed from `bin/healthcheck.js` in order to support the Docker `HEALTHCHECK` command.
- threw in a couple of miscellaneous cleanup things in here 
  - do not want to default `SUPPORT_EMAIL` to api.va.gov because it creates spam for support if devs do not configure their local env properly - see https://lighthouseva.slack.com/archives/C01931CFMTQ/p1604350330255400?thread_ts=1604350109.254200&cid=C01931CFMTQ. if devs are using the real GovDelivery but don't configure `SUPPORT_EMAIL`, they should find out by that failing rather than creating production emails and Salesforce tickets.
  - removed a couple stray 503s for services that aren't configured since all services are required

### Questions/Desired Feedback

- the design here removes the `/internal/developer-portal-backend` prefix from the paths in the developer portal backend. would we like to maintain some kind of prefix like that on the route so that it's clear what the routes are for where they're consumed? so, for example, perhaps `https://api.va.gov/developer-portal/public` is more expressive than `https://api.va.gov/public`.
  - either way, would love to shorten that prefix if possible while i'm making these changes, if other people are amenable to that.
- do `/` or `/health` need to be accessible from the gateway for any reason?