### PR TITLE
Remove legacy routes without /internal/developer-portal prefix

### DIFF
--- a/app.test.ts
+++ b/app.test.ts
@@ -14,14 +14,3 @@ describe('App routing', () => {
     });
   });
 });
-
-describe('/reports/signups', () => {
-  it('sends a 400 response and descriptive errors if validations fail', async () => {
-    const response = await request.get('/reports/signups?span=Gimli');
-
-    expect(response.status).toEqual(400);
-    expect(response.body).toEqual({
-      errors: ['"span" must be one of [week, month]'],
-    });
-  });
-});

--- a/app.ts
+++ b/app.ts
@@ -11,11 +11,7 @@ import { DynamoConfig, KongConfig } from './types';
 import SlackService from './services/SlackService';
 import DynamoService from './services/DynamoService';
 import SignupMetricsService from './services/SignupMetricsService';
-import configureRoutes, { validationMiddleware } from './routes';
-import developerApplicationHandler, { applySchema } from './routes/DeveloperApplication';
-import contactUsHandler, { contactSchema } from './routes/ContactUs';
-import healthCheckHandler from './routes/HealthCheck';
-import signupsReportHandler, { signupsReportSchema } from './routes/management/SignupsReport';
+import configureRoutes from './routes';
 
 function loggingMiddleware(tokens, req, res): string {
   return JSON.stringify({
@@ -153,21 +149,6 @@ export default function configureApp(): express.Application {
     signups,
     slack,
   });
-
-  // OLD ROUTES
-  app.post('/developer_application',
-    validationMiddleware(applySchema, 'body'),
-    developerApplicationHandler(kong, okta, dynamo, govDelivery, slack));
-
-  app.post('/contact-us',
-    validationMiddleware(contactSchema, 'body'),
-    contactUsHandler(govDelivery));
-
-  app.get('/health_check', healthCheckHandler(kong, okta, dynamo, govDelivery, slack));
-
-  app.get('/reports/signups',
-    validationMiddleware(signupsReportSchema, 'query'),
-    signupsReportHandler(signups, slack));
 
   app.use(Sentry.Handlers.errorHandler());
 

--- a/routes/ContactUs.integration.ts
+++ b/routes/ContactUs.integration.ts
@@ -5,10 +5,8 @@ import nock from 'nock';
 import configureApp from '../app';
 
 const request = supertest(configureApp());
-describe.each([
-  '/contact-us',
-  '/internal/developer-portal/public/contact-us',
-])('%s', (route: string) => {
+const route = '/internal/developer-portal/public/contact-us';
+describe(route, () => {
   const govDelivery = nock(`${process.env.GOVDELIVERY_HOST}`);
 
   const supportReq = {

--- a/routes/DeveloperApplication.integration.ts
+++ b/routes/DeveloperApplication.integration.ts
@@ -8,10 +8,8 @@ import { oktaAuthMocks } from '../types/mocks';
 import { OKTA_AUTHZ_ENDPOINTS } from '../config/apis';
 
 const request = supertest(configureApp());
-describe.each([
-  '/developer_application',
-  '/internal/developer-portal/public/developer_application',
-])('%s', (route: string) => {
+const route = '/internal/developer-portal/public/developer_application';
+describe(route, () => {
   const kong = nock(`http://${process.env.KONG_HOST}:8000`);
   const okta = nock(process.env.OKTA_HOST);
   const dynamoDB = nock(`${process.env.DYNAMODB_ENDPOINT}`);

--- a/routes/HealthCheck.integration.ts
+++ b/routes/HealthCheck.integration.ts
@@ -5,10 +5,8 @@ import nock from 'nock';
 import configureApp from '../app';
 
 const request = supertest(configureApp());
-describe.each([
-  '/health_check',
-  '/internal/developer-portal/public/health_check',
-])('%s', (route: string) => {
+const route = '/internal/developer-portal/public/health_check';
+describe('/internal/developer-portal/public/health_check', () => {
   const kong = nock(`http://${process.env.KONG_HOST}:8000`);
   const okta = nock(process.env.OKTA_HOST);
   const dynamoDB = nock(`${process.env.DYNAMODB_ENDPOINT}`);

--- a/routes/HealthCheck.integration.ts
+++ b/routes/HealthCheck.integration.ts
@@ -6,7 +6,7 @@ import configureApp from '../app';
 
 const request = supertest(configureApp());
 const route = '/internal/developer-portal/public/health_check';
-describe('/internal/developer-portal/public/health_check', () => {
+describe(route, () => {
   const kong = nock(`http://${process.env.KONG_HOST}:8000`);
   const okta = nock(process.env.OKTA_HOST);
   const dynamoDB = nock(`${process.env.DYNAMODB_ENDPOINT}`);

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -11,7 +11,7 @@ import contactUsHandler, { contactSchema } from './ContactUs';
 import healthCheckHandler from './HealthCheck';
 import signupsReportHandler, { signupsReportSchema } from './management/SignupsReport';
 
-export function validationMiddleware(schema: Schema, toValidate: string) {
+function validationMiddleware(schema: Schema, toValidate: string) {
   return (req: Request, res: Response, next: NextFunction): void => {
     const { error } = schema.validate(req[toValidate]);
     if (error) {

--- a/routes/management/SignupsReport.integration.ts
+++ b/routes/management/SignupsReport.integration.ts
@@ -8,10 +8,8 @@ const request = supertest(configureApp());
 const dynamoDB = nock(`${process.env.DYNAMODB_ENDPOINT}`);
 const slack = nock(process.env.SLACK_BASE_URL);
 
-describe.each([
-  '/reports/signups',
-  '/internal/developer-portal/admin/reports/signups',
-])('%s', (route: string) => {
+const route = '/internal/developer-portal/admin/reports/signups';
+describe(route, () => {
   beforeEach(() => {
     nock.cleanAll();
   });
@@ -29,6 +27,15 @@ describe.each([
 
     expect(response.status).toEqual(200);
     expect(response.text).toEqual('OK');
+  });
+
+  it('sends a 400 response and descriptive errors if validations fail', async () => {
+    const response = await request.get(`${route}?span=Gimli`);
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toEqual({
+      errors: ['"span" must be one of [week, month]'],
+    });
   });
 
   it('sends a 500 response if slack responds with 500', async () => {


### PR DESCRIPTION
for [API-3337](https://vajira.max.gov/browse/API-3337). deletes old routes that were removed from use in the following PRs:

- department-of-veterans-affairs/developer-portal#533
- department-of-veterans-affairs/lighthouse-platform-tasks#1