### PR TITLE
Api 1818 add environment to slack post for signups

### DIFF
--- a/services/SignupMetricsService.integration.ts
+++ b/services/SignupMetricsService.integration.ts
@@ -384,7 +384,6 @@ describeFunc('signups module', () => {
           health: 3,
           verification: 3,
         },
-        environment: "Development",
       });
     });
 
@@ -416,7 +415,6 @@ describeFunc('signups module', () => {
           facilities: 5,
           health: 1,
         },
-        environment: "Development",
       });
     });
 
@@ -438,7 +436,6 @@ describeFunc('signups module', () => {
           health: 1,
           verification: 1,
         },
-        environment: "Development",
       });
     });
 
@@ -459,7 +456,6 @@ describeFunc('signups module', () => {
           vaForms: 5,
           verification: 1,
         },
-        environment: "Development",
       });
     });
 
@@ -483,7 +479,6 @@ describeFunc('signups module', () => {
           vaForms: 3,
           verification: 4,
         },
-        environment: "Development",
       });
     });
 
@@ -501,7 +496,6 @@ describeFunc('signups module', () => {
           benefits: 1,
           claims: 1,
         },
-        environment: "Development",
       });
     });
 
@@ -524,7 +518,6 @@ describeFunc('signups module', () => {
           vaForms: 2,
           verification: 1,
         },
-        environment: "Development",
       });
     });
   });

--- a/services/SignupMetricsService.integration.ts
+++ b/services/SignupMetricsService.integration.ts
@@ -384,7 +384,7 @@ describeFunc('signups module', () => {
           health: 3,
           verification: 3,
         },
-        environment: "Development"
+        environment: "Development",
       });
     });
 

--- a/services/SignupMetricsService.integration.ts
+++ b/services/SignupMetricsService.integration.ts
@@ -384,6 +384,7 @@ describeFunc('signups module', () => {
           health: 3,
           verification: 3,
         },
+        environment: "Development"
       });
     });
 
@@ -415,6 +416,7 @@ describeFunc('signups module', () => {
           facilities: 5,
           health: 1,
         },
+        environment: "Development",
       });
     });
 
@@ -436,6 +438,7 @@ describeFunc('signups module', () => {
           health: 1,
           verification: 1,
         },
+        environment: "Development",
       });
     });
 
@@ -456,6 +459,7 @@ describeFunc('signups module', () => {
           vaForms: 5,
           verification: 1,
         },
+        environment: "Development",
       });
     });
 
@@ -479,6 +483,7 @@ describeFunc('signups module', () => {
           vaForms: 3,
           verification: 4,
         },
+        environment: "Development",
       });
     });
 
@@ -496,6 +501,7 @@ describeFunc('signups module', () => {
           benefits: 1,
           claims: 1,
         },
+        environment: "Development",
       });
     });
 
@@ -518,6 +524,7 @@ describeFunc('signups module', () => {
           vaForms: 2,
           verification: 1,
         },
+        environment: "Development",
       });
     });
   });

--- a/services/SignupMetricsService.ts
+++ b/services/SignupMetricsService.ts
@@ -6,8 +6,8 @@ const DEFAULT_TABLE = 'dvp-prod-developer-portal-users';
 const ENVIRONMENTS = {
   'dvp-dev-developer-portal-users': 'Development',
   'dvp-prod-developer-portal-users': 'Production',
-  'dvp-staging-developer-portal-users': 'Staging'
-}
+  'dvp-staging-developer-portal-users': 'Staging',
+};
 
 export interface SignupQueryOptions {
   startDate?: Moment;
@@ -134,7 +134,7 @@ export default class SignupMetricsService {
         result.apiCounts[apiId]++;
       });
     }
-    
+
     return result;
   }
 

--- a/services/SignupMetricsService.ts
+++ b/services/SignupMetricsService.ts
@@ -7,6 +7,7 @@ const ENVIRONMENTS = {
   'dvp-dev-developer-portal-users': 'Development',
   'dvp-prod-developer-portal-users': 'Production',
   'dvp-staging-developer-portal-users': 'Staging',
+  'fake-users-table': 'Test',
 };
 
 export interface SignupQueryOptions {
@@ -34,12 +35,12 @@ export interface ApiSignupCounts {
 export interface SignupCountResult {
   total: number;
   apiCounts: ApiSignupCounts;
-  environment: string;
 }
 
 export default class SignupMetricsService {
   private tableName: string = process.env.DYNAMODB_TABLE || DEFAULT_TABLE;
   private dynamoService: DynamoService;
+  public static environment: string = ENVIRONMENTS[process.env.DYNAMODB_TABLE || DEFAULT_TABLE];
 
   public constructor(dynamoService: DynamoService) {
     this.dynamoService = dynamoService;
@@ -109,7 +110,6 @@ export default class SignupMetricsService {
         verification: 0,
         claims: 0,
       },
-      environment: ENVIRONMENTS[this.tableName],
     };
 
     const uniqueSignups: Signup[] = await this.getUniqueSignups(options);
@@ -137,7 +137,7 @@ export default class SignupMetricsService {
 
     return result;
   }
-
+ 
   private buildFilterParams(options: SignupQueryOptions): FilterParams {
     let filterParams = {};
     if (options.startDate && options.endDate) {

--- a/services/SignupMetricsService.ts
+++ b/services/SignupMetricsService.ts
@@ -3,6 +3,11 @@ import { Moment } from 'moment';
 import DynamoService, { FilterParams } from './DynamoService';
 
 const DEFAULT_TABLE = 'dvp-prod-developer-portal-users';
+const ENVIRONMENTS = {
+  'dvp-dev-developer-portal-users': 'Development',
+  'dvp-prod-developer-portal-users': 'Production',
+  'dvp-staging-developer-portal-users': 'Staging'
+}
 
 export interface SignupQueryOptions {
   startDate?: Moment;
@@ -29,6 +34,7 @@ export interface ApiSignupCounts {
 export interface SignupCountResult {
   total: number;
   apiCounts: ApiSignupCounts;
+  environment: string;
 }
 
 export default class SignupMetricsService {
@@ -103,6 +109,7 @@ export default class SignupMetricsService {
         verification: 0,
         claims: 0,
       },
+      environment: ENVIRONMENTS[this.tableName],
     };
 
     const uniqueSignups: Signup[] = await this.getUniqueSignups(options);
@@ -127,7 +134,7 @@ export default class SignupMetricsService {
         result.apiCounts[apiId]++;
       });
     }
-
+    
     return result;
   }
 

--- a/services/SlackService.test.ts
+++ b/services/SlackService.test.ts
@@ -79,6 +79,7 @@ describe('SlackService', () => {
         verification: 0,
         claims: 0,
       },
+      environment: "Development"
     };
 
     const allTime = {
@@ -93,6 +94,7 @@ describe('SlackService', () => {
         verification: 7,
         claims: 8,
       },
+      environment: "Development"
     };
 
     const res = await service.sendSignupsMessage(duration, formattedEnd, thisWeek, allTime);
@@ -105,7 +107,7 @@ describe('SlackService', () => {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: '*Weekly Sign-ups and Access Requests* for Week Ending 12/17/2003',
+            text: '*Weekly Sign-ups and Access Requests (Development)* for Week Ending 12/17/2003',
           },
         },
         {

--- a/services/SlackService.test.ts
+++ b/services/SlackService.test.ts
@@ -79,7 +79,6 @@ describe('SlackService', () => {
         verification: 0,
         claims: 0,
       },
-      environment: "Development",
     };
 
     const allTime = {
@@ -94,7 +93,6 @@ describe('SlackService', () => {
         verification: 7,
         claims: 8,
       },
-      environment: "Development",
     };
 
     const res = await service.sendSignupsMessage(duration, formattedEnd, thisWeek, allTime);
@@ -107,7 +105,14 @@ describe('SlackService', () => {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: '*Weekly Sign-ups and Access Requests (Development)* for Week Ending 12/17/2003',
+            text: '*Weekly Sign-ups and Access Requests* for Week Ending 12/17/2003',
+          },
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*Environment:* Test',
           },
         },
         {

--- a/services/SlackService.test.ts
+++ b/services/SlackService.test.ts
@@ -79,7 +79,7 @@ describe('SlackService', () => {
         verification: 0,
         claims: 0,
       },
-      environment: "Development"
+      environment: "Development",
     };
 
     const allTime = {
@@ -94,7 +94,7 @@ describe('SlackService', () => {
         verification: 7,
         claims: 8,
       },
-      environment: "Development"
+      environment: "Development",
     };
 
     const res = await service.sendSignupsMessage(duration, formattedEnd, thisWeek, allTime);

--- a/services/SlackService.ts
+++ b/services/SlackService.ts
@@ -130,7 +130,7 @@ export default class SlackService implements MonitoredService {
           text: {
             type: 'mrkdwn',
             text: `*Environment:* ${SignupMetricsService.environment}`,
-          }
+          },
         },
         {
           type: 'divider',

--- a/services/SlackService.ts
+++ b/services/SlackService.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import { MonitoredService, ServiceHealthCheckResponse } from '../types';
-import { SignupCountResult } from './SignupMetricsService';
+import SignupMetricsService, { SignupCountResult } from './SignupMetricsService';
 
 /* 
 WebAPISlackOptions are extras provided for specific APIs. Channel is related to messaging.
@@ -122,8 +122,15 @@ export default class SlackService implements MonitoredService {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `*${titleDuration}ly Sign-ups and Access Requests (${allTimeSignups.environment})* for ${titleDuration} Ending ${endDate}`,
+            text: `*${titleDuration}ly Sign-ups and Access Requests* for ${titleDuration} Ending ${endDate}`,
           },
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*Environment:* ${SignupMetricsService.environment}`,
+          }
         },
         {
           type: 'divider',

--- a/services/SlackService.ts
+++ b/services/SlackService.ts
@@ -122,7 +122,7 @@ export default class SlackService implements MonitoredService {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `*${titleDuration}ly Sign-ups and Access Requests* for ${titleDuration} Ending ${endDate}`,
+            text: `*${titleDuration}ly Sign-ups and Access Requests (${allTimeSignups.environment})* for ${titleDuration} Ending ${endDate}`,
           },
         },
         {


### PR DESCRIPTION
This PR is for [API-1818](https://vajira.max.gov/browse/API-1818). It adds the environment to the slack message that is generated from counting signups so that it is easier to differentiate the messages. 