### PR TITLE
Add CORS and env var for local development so FE can call BE

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ GOVDELIVERY_HOST=http://mock:3001/services/govdelivery
 GOVDELIVERY_KEY=123
 OKTA_HOST=http://mock:3001/services/okta
 OKTA_TOKEN=123
+DEVELOPER_PORTAL_URL=http://localhost:3001
 ```
 
 With a `.env` in place, use `docker-compose up` to run the application.
@@ -45,6 +46,10 @@ Example CURL request:
 curl --location --request POST 'https://lighthouseva.slack.com/api/auth.test' \
 --header 'Authorization: Bearer <Put SLACK_TOKEN here>'
 ```
+
+### Running Developer Portal Backend and Developer Portal together locally
+1. Set `DEVELOPER_PORTAL_URL` in the developer-portal-backend `.env` to where your Developer Portal is running (default is `http://localhost:3001`)
+2. Set `REACT_APP_DEVELOPER_PORTAL_SELF_SERVICE_URL` in the developer-portal `.env.local` to where your Developer Portal Backend is running (default is `http://localhost:9999`)
 
 ## Development
 The `docker-compose.yml` file defines volumes in the app container so that changes made to the code on the host are picked up inside the container. The default start commmand also has the server hot-reload on changes, so it's convenient to leave the containers running in the background while developing. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -707,6 +707,15 @@
       "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
       "dev": true
     },
+    "@types/cors": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.8.tgz",
+      "integrity": "sha512-fO3gf3DxU2Trcbr75O7obVndW/X5k8rJNZkLXlQWStTHhP71PkRqjwPIEI0yMnJdg9R9OasjU+Bsr+Hr1xy/0w==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1957,6 +1966,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -4954,6 +4972,11 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/objects-to-csv": "^1.3.0",
     "aws-sdk": "^2.640.0",
     "axios": "^0.19.2",
+    "cors": "^2.8.5",
     "express": "~4.16.1",
     "handlebars": "^4.7.3",
     "lodash.pick": "^4.4.0",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@types/command-line-args": "^5.0.0",
+    "@types/cors": "^2.8.8",
     "@types/express": "^4.17.3",
     "@types/handlebars": "^4.1.0",
     "@types/hapi__joi": "^17.1.2",

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -10,6 +10,7 @@ import developerApplicationHandler, { applySchema } from './DeveloperApplication
 import contactUsHandler, { contactSchema } from './ContactUs';
 import healthCheckHandler from './HealthCheck';
 import signupsReportHandler, { signupsReportSchema } from './management/SignupsReport';
+import cors from 'cors';
 
 function validationMiddleware(schema: Schema, toValidate: string) {
   return (req: Request, res: Response, next: NextFunction): void => {
@@ -49,6 +50,16 @@ const configureRoutes = (app: Express, services: AppServices): void => {
     signups,
     slack,
   } = services;
+
+  /**
+   * LOCAL DEV
+   */
+  if(process.env.DEVELOPER_PORTAL_URL) {
+    const options: cors.CorsOptions = {
+      origin: process.env.DEVELOPER_PORTAL_URL,
+    };  
+    app.use(cors(options));
+  }
 
   /**
    * PUBLIC


### PR DESCRIPTION
[API-1991](https://vajira.max.gov/browse/API-1991)
Add cors package so that will activate only when `DEVELOPER_PORTAL_URL` is set to enable cross-origin requests
Add instructions on how to run developer-portal and developer-portal-backend in tandem locally