### PR TITLE
Remove the protocol guard

### DIFF
--- a/services/GovDeliveryService.ts
+++ b/services/GovDeliveryService.ts
@@ -96,11 +96,6 @@ export default class GovDeliveryService implements MonitoredService {
   public client: AxiosInstance;
 
   constructor({ token, host, supportEmailRecipient }) {
-    // TODO: Remove when GOVDELIVERY_HOST is updated in Parameter Store to include protocol
-    // Currently used to handle mock server using http protocol and Parameter Store variable not having a protocol
-    if(!host.match(/^https?:\/\//)){
-      host = `https://${host}`;
-    }
     this.host = host;
     this.supportEmailRecipient = supportEmailRecipient;
     this.welcomeTemplate = Handlebars.compile(WELCOME_TEMPLATE);


### PR DESCRIPTION
[API-2371](https://vajira.max.gov/browse/API-2371)
I updated the Parameter Store with the `https://` protocol for `GOVDELIVERY_HOST` in dev. So now we can remove the protocol guard on the service.

[Parameter in Parameter Store](https://console.amazonaws-us-gov.com/systems-manager/parameters/dvp/dev/developer-portal-backend/GOVDELIVERY_HOST/description?region=us-gov-west-1&tab=Table)