### PR TITLE
Add in missing field

### DIFF
--- a/routes/ContactUs.test.ts
+++ b/routes/ContactUs.test.ts
@@ -315,6 +315,18 @@ describe('validations', () => {
   
         expect(result.error.message).toEqual('"apiInternalOnly" must be a boolean');
       });
+
+      describe('is true', () => {
+        describe('apiInternalOnlyDetails', () => {
+          it('is required', () => {
+            const payload = { ...publishingPayload, apiInternalOnly: true };
+      
+            const result = contactSchema.validate(payload);
+            
+            expect(result.error.message).toEqual('"apiInternalOnlyDetails" is required');
+          });
+        });
+      });
     });
 
     describe("description", () => {

--- a/routes/ContactUs.ts
+++ b/routes/ContactUs.ts
@@ -26,6 +26,7 @@ type PublishingSupportRequest = {
   apiDetails: string;
   apiDescription?: string;
   apiInternalOnly: boolean;
+  apiInternalOnlyDetails?: string;
   apiOtherInfo?: string;
 } & ContactDetails
 
@@ -44,6 +45,10 @@ export const contactSchema = Joi.object().keys({
     apiDetails: Joi.string().required(),
     apiDescription: Joi.string().optional(),
     apiInternalOnly: Joi.boolean().required(),
+    apiInternalOnlyDetails: Joi.string().forbidden().when('apiInternalOnly', {
+      is: Joi.boolean().required().valid(true),
+      then: Joi.required(),
+    }),
     apiOtherInfo: Joi.string().optional(),
     description: Joi.forbidden(),
     apis: Joi.forbidden(),
@@ -62,6 +67,7 @@ export default function contactUsHandler(govDelivery: GovDeliveryService) {
           apiDetails: req.body.apiDetails,
           apiDescription: req.body.apiDescription,
           apiInternalOnly: req.body.apiInternalOnly,
+          apiInternalOnlyDetails: req.body.apiInternalOnlyDetails,
           apiOtherInfo: req.body.apiOtherInfo,
         };
         

--- a/services/GovDeliveryService.ts
+++ b/services/GovDeliveryService.ts
@@ -44,6 +44,7 @@ export interface PublishingSupportEmail {
   apiDetails: string;
   apiDescription?: string;
   apiInternalOnly: boolean;
+  apiInternalOnlyDetails?: string;
   apiOtherInfo?: string;
 }
 export interface EmailResponse {

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -118,6 +118,12 @@ export const PUBLISHING_SUPPORT_TEMPLATE = `<ul>
 </li>
 <li>
     <div>
+        <div>Internal Only Details:</div>
+        <div>{{apiInternalOnlyDetails}}</div>
+    </div>
+</li>
+<li>
+    <div>
         <div>Other Info:</div>
         <div>{{apiOtherInfo}}</div>
     </div>


### PR DESCRIPTION
This adds in a field that was missing in the previous PR. This field (`apiInternalOnlyDetails`) is a required field when a user has answered `true` to `apiInternalOnly`, but otherwise should not be present. 