### PR TITLE
Add claims attributes to backend

### DIFF
--- a/config/apis.test.ts
+++ b/config/apis.test.ts
@@ -19,7 +19,7 @@ describe('API constants', () => {
       vaForms: 'va_forms',
     });
   });
-  
+
   it('APIS_TO_PROPER_NAMES', () => {
     expect(APIS_TO_PROPER_NAMES).toEqual({
       claimsAttributes: 'Claims Attributes API',

--- a/config/apis.test.ts
+++ b/config/apis.test.ts
@@ -12,8 +12,8 @@ import {
 describe('API constants', () => {
   it('APIS_TO_ACLS', () => {
     expect(APIS_TO_ACLS).toEqual({
-      claimsAttributes: 'claims_attributes',
       benefits: 'vba_documents',
+      claimsAttributes: 'claims_attributes',
       confirmation: 'veteran_confirmation',
       facilities: 'va_facilities',
       vaForms: 'va_forms',
@@ -22,9 +22,9 @@ describe('API constants', () => {
 
   it('APIS_TO_PROPER_NAMES', () => {
     expect(APIS_TO_PROPER_NAMES).toEqual({
-      claimsAttributes: 'Claims Attributes API',
       benefits: 'Benefits Intake API',
       claims: 'Claims API',
+      claimsAttributes: 'Claims Attributes API',
       communityCare: 'Community Care Eligibility API',
       confirmation: 'Veteran Confirmation API',
       facilities: 'VA Facilities API',
@@ -36,8 +36,8 @@ describe('API constants', () => {
 
   it('KONG_CONSUMER_APIS', () => {
     expect(KONG_CONSUMER_APIS).toEqual([
-      'claimsAttributes',
       'benefits',
+      'claimsAttributes',
       'facilities',
       'vaForms',
       'confirmation',
@@ -64,8 +64,8 @@ describe('API constants', () => {
 
   it('API_LIST', () => {
     expect(API_LIST).toEqual([
-      'claimsAttributes',
       'benefits',
+      'claimsAttributes',
       'facilities',
       'vaForms',
       'confirmation',

--- a/config/apis.test.ts
+++ b/config/apis.test.ts
@@ -12,15 +12,17 @@ import {
 describe('API constants', () => {
   it('APIS_TO_ACLS', () => {
     expect(APIS_TO_ACLS).toEqual({
+      claimsAttributes: 'claims_attributes',
       benefits: 'vba_documents',
       confirmation: 'veteran_confirmation',
       facilities: 'va_facilities',
       vaForms: 'va_forms',
     });
   });
-
+  
   it('APIS_TO_PROPER_NAMES', () => {
     expect(APIS_TO_PROPER_NAMES).toEqual({
+      claimsAttributes: 'Claims Attributes API',
       benefits: 'Benefits Intake API',
       claims: 'Claims API',
       communityCare: 'Community Care Eligibility API',
@@ -34,6 +36,7 @@ describe('API constants', () => {
 
   it('KONG_CONSUMER_APIS', () => {
     expect(KONG_CONSUMER_APIS).toEqual([
+      'claimsAttributes',
       'benefits',
       'facilities',
       'vaForms',
@@ -61,6 +64,7 @@ describe('API constants', () => {
 
   it('API_LIST', () => {
     expect(API_LIST).toEqual([
+      'claimsAttributes',
       'benefits',
       'facilities',
       'vaForms',

--- a/config/apis.ts
+++ b/config/apis.ts
@@ -25,14 +25,14 @@ const oauthAPIList: OAuthAPI[] = [
 
 const keyAuthAPIList: KeyAuthAPI[] = [
   {
-    name: 'Claims Attributes API',
-    key: 'claimsAttributes',
-    acl: 'claims_attributes',
-  },
-  {
     name: 'Benefits Intake API',
     key: 'benefits',
     acl: 'vba_documents',
+  },
+  {
+    name: 'Claims Attributes API',
+    key: 'claimsAttributes',
+    acl: 'claims_attributes',
   },
   {
     name: 'VA Facilities API',

--- a/config/apis.ts
+++ b/config/apis.ts
@@ -25,6 +25,11 @@ const oauthAPIList: OAuthAPI[] = [
 
 const keyAuthAPIList: KeyAuthAPI[] = [
   {
+    name: 'Claims Attributes API',
+    key: 'claimsAttributes',
+    acl: 'claims_attributes',
+  },
+  {
     name: 'Benefits Intake API',
     key: 'benefits',
     acl: 'vba_documents',


### PR DESCRIPTION
noticed there was an error being sent to the frontend from the server due to claims attributes not being added

for reference, the acl comes from [HERE](https://github.com/department-of-veterans-affairs/lighthouse-platform-tools/blob/660bfaff196b1051fcafb86cc5739c75b3346fd2/environments/sandbox/config/forward-proxy.yaml#L411). 