### PR TITLE
Allow for non-required string fields to be blank strings

### DIFF
--- a/routes/ContactUs.test.ts
+++ b/routes/ContactUs.test.ts
@@ -298,6 +298,24 @@ describe('validations', () => {
       });
     });
 
+    describe('apiDescription', () => {
+      it('can be blank', () => {
+        const payload = { ...publishingPayload, apiDescription: "" };
+  
+        const result = contactSchema.validate(payload);
+        
+        expect(result.error).toBeFalsy();
+      });
+
+      it('is a string', () => {
+        const payload = { ...publishingPayload, apiDescription: { potatoes: 'boil em, mash em, stick em in a stew' } };
+  
+        const result = contactSchema.validate(payload);
+  
+        expect(result.error?.message).toEqual('"apiDescription" must be a string');
+      });
+    });
+
     describe('apiInternalOnly', () => {
       it('is required', () => {
         const payload = { ...publishingPayload, apiInternalOnly: undefined };

--- a/routes/ContactUs.ts
+++ b/routes/ContactUs.ts
@@ -44,13 +44,13 @@ export const contactSchema = Joi.object().keys({
 }).when(Joi.object({type: Joi.valid(SubmissionType.PUBLISHING).required()}).unknown(), {
   then: Joi.object({
     apiDetails: Joi.string().required(),
-    apiDescription: Joi.string().optional(),
+    apiDescription: Joi.string().allow(''),
     apiInternalOnly: Joi.boolean().required(),
     apiInternalOnlyDetails: Joi.string().forbidden().when('apiInternalOnly', {
       is: Joi.boolean().required().valid(true),
       then: Joi.required(),
     }),
-    apiOtherInfo: Joi.string().optional(),
+    apiOtherInfo: Joi.string().allow(''),
     description: Joi.forbidden(),
     apis: Joi.forbidden(),
   }),


### PR DESCRIPTION
This updates the endpoint to allow blank strings for non-required fields