### PR TITLE
Fix docker compose up

### DIFF
--- a/dev/mocks/Dockerfile
+++ b/dev/mocks/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:14
 WORKDIR /home/node
 COPY package.json package-lock.json ./
 RUN npm install

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node dist/server",
-    "watch": "nodemon --watch '*.ts' --exec 'ts-node' server.ts",
+    "watch": "nodemon --watch '*.ts' --exec 'ts-node' --files server.ts",
     "watch:debug": "nodemon --watch '*.ts' --exec 'node --require ts-node/register --inspect-brk=0.0.0.0:9229 server.ts'",
     "lint": "NODE_OPTIONS=\"--max_old_space_size=1536\" eslint --ext .js,.ts .",
     "test": "jest",


### PR DESCRIPTION
[API-7699](https://vajira.max.gov/browse/API-7699)
The --files flag forces ts-node to load all files, which includes custom type definitions, which it wasn't seeing before. I first attempted to move Okta's self defined types, but their `createApplication` method is not correctly typed. It is not able to determine whether the created application is an OAuth/OpenID application or not, which causes type errors in our code.