### PR TITLE
changed businessModel to optional in Production Access Request

### DIFF
--- a/routes/ProductionRequest.test.ts
+++ b/routes/ProductionRequest.test.ts
@@ -272,6 +272,14 @@ describe('validations', () => {
   });
 
   describe('businessModel', () => {
+    it('is not required', () => {
+      const payload = { ...defaultPayload, businessModel: undefined };
+
+      const result = productionSchema.validate(payload);
+
+      expect(result.error?.message).toEqual(undefined);
+    });
+
     it('is a string', () => {
       const payload = { ...defaultPayload, businessModel: 12345 };
 

--- a/routes/ProductionRequest.ts
+++ b/routes/ProductionRequest.ts
@@ -14,7 +14,7 @@ export const productionSchema = Joi.object()
     appDescription: Joi.string(),
     appName: Joi.string(),
     breachManagementProcess: Joi.string(),
-    businessModel: Joi.string().required(),
+    businessModel: Joi.string(),
     centralizedBackendLog: Joi.string(),
     distributingAPIKeysToCustomers: Joi.boolean(),
     exposeVeteranInformationToThirdParties: Joi.boolean(),


### PR DESCRIPTION
Signed-off-by: Braden Shipley <bradenrshipley@gmail.com>

This field was previously required in the Production Request field schema, however it should be optional `if Forms and/or Facilities == selected`. See content below:
![image](https://user-images.githubusercontent.com/27251568/130091253-da519024-05b4-4c9e-8acf-dfd632007734.png)
