### PR TITLE
remove implicit from okta grant_types

### DIFF
--- a/dev/mocks/json-mocks/services/okta/#api#v1#apps/POST/mock/success.json
+++ b/dev/mocks/json-mocks/services/okta/#api#v1#apps/POST/mock/success.json
@@ -64,7 +64,6 @@
         "code"
       ],
       "grant_types": [
-        "implicit",
         "authorization_code"
       ],
       "application_type": "native",

--- a/models/Application.test.ts
+++ b/models/Application.test.ts
@@ -27,11 +27,7 @@ describe('Application', () => {
 
       expect(oauthClient.application_type).toEqual('web');
       expect(oauthClient.response_types.sort()).toEqual(['code', 'id_token', 'token']);
-      expect(oauthClient.grant_types.sort()).toEqual([
-        'authorization_code',
-        'implicit',
-        'refresh_token',
-      ]);
+      expect(oauthClient.grant_types.sort()).toEqual(['authorization_code', 'refresh_token']);
     });
 
     it('be web fields when applicationType is web', () => {
@@ -44,11 +40,7 @@ describe('Application', () => {
 
       expect(oauthClient.application_type).toEqual('web');
       expect(oauthClient.response_types.sort()).toEqual(['code', 'id_token', 'token']);
-      expect(oauthClient.grant_types.sort()).toEqual([
-        'authorization_code',
-        'implicit',
-        'refresh_token',
-      ]);
+      expect(oauthClient.grant_types.sort()).toEqual(['authorization_code', 'refresh_token']);
     });
 
     it('be native fields when applicationType is native', () => {

--- a/models/Application.ts
+++ b/models/Application.ts
@@ -67,7 +67,6 @@ export default class Application implements OktaApplication {
       this.settings.credentials = { oauthClient: { token_endpoint_auth_method: 'none' } };
     } else if (applicationType === 'web') {
       this.settings.settings.oauthClient.response_types.push('token', 'id_token');
-      this.settings.settings.oauthClient.grant_types.push('implicit');
     }
   }
 


### PR DESCRIPTION
Remove implicit grant_type from Okta application via the apply flow per [API-9430](https://vajira.max.gov/browse/API-9430).