### PR TITLE
Added the 508 compliance field to the production access endpoint

### DIFF
--- a/routes/ProductionRequest.integration.ts
+++ b/routes/ProductionRequest.integration.ts
@@ -28,6 +28,7 @@ describe(route, () => {
     centralizedBackendLog: 'non-existent',
     distributingAPIKeysToCustomers: false,
     exposeVeteranInformationToThirdParties: false,
+    is508Compliant: true,
     listedOnMyHealthApplication: false,
     monitizationExplanation: 'n/a',
     monitizedVeteranInformation: false,
@@ -37,9 +38,7 @@ describe(route, () => {
     phoneNumber: '555-867-5309',
     piiStorageMethod: 'Locking away in the fires from whence it came.',
     platforms: 'iOS',
-    policyDocuments: [
-      'www.example.com/tos',
-    ],
+    policyDocuments: ['www.example.com/tos'],
     primaryContact: {
       email: 'sam@fellowship.com',
       firstName: 'Samwise',
@@ -53,21 +52,16 @@ describe(route, () => {
       firstName: 'Frodo',
       lastName: 'Baggins',
     },
-    signUpLink: [
-      'www.one2bindthem.com/signup',
-    ],
-    statusUpdateEmails: [
-      'sam@fellowship.com',
-    ],
+    signUpLink: ['www.one2bindthem.com/signup'],
+    statusUpdateEmails: ['sam@fellowship.com'],
     storePIIOrPHI: false,
-    supportLink: [
-      'www.one2bindthem.com/support',
-    ],
+    supportLink: ['www.one2bindthem.com/support'],
     thirdPartyInfoDescription: 'n/a',
     valueProvided: 'n/a',
     vasiSystemName: 'asdf',
     veteranFacing: false,
-    veteranFacingDescription: 'Now the Elves made many rings; but secretly Sauron made One Ring to rule all the others, and their power was bound up with it, to be subject wholly to it and to last only so long as it too should last.',
+    veteranFacingDescription:
+      'Now the Elves made many rings; but secretly Sauron made One Ring to rule all the others, and their power was bound up with it, to be subject wholly to it and to last only so long as it too should last.',
     vulnerabilityManagement: 'golem',
     website: 'www.one2bindthem.com',
   };
@@ -82,6 +76,7 @@ describe(route, () => {
       centralizedBackendLog: 'non-existent',
       distributingAPIKeysToCustomers: false,
       exposeVeteranInformationToThirdParties: false,
+      is508Compliant: true,
       listedOnMyHealthApplication: false,
       monitizationExplanation: 'n/a',
       monitizedVeteranInformation: false,
@@ -104,7 +99,7 @@ describe(route, () => {
       vasiSystemName: 'asdf',
       veteranFacing: false,
       veteranFacingDescription:
-      'Now the Elves made many rings; but secretly Sauron made One Ring to rule all the others, and their power was bound up with it, to be subject wholly to it and to last only so long as it too should last.',
+        'Now the Elves made many rings; but secretly Sauron made One Ring to rule all the others, and their power was bound up with it, to be subject wholly to it and to last only so long as it too should last.',
       vulnerabilityManagement: 'golem',
       website: 'www.one2bindthem.com',
     });

--- a/routes/ProductionRequest.test.ts
+++ b/routes/ProductionRequest.test.ts
@@ -40,6 +40,7 @@ describe('productionRequestHandler', () => {
         centralizedBackendLog: 'non-existent',
         distributingAPIKeysToCustomers: false,
         exposeVeteranInformationToThirdParties: false,
+        is508Compliant: true,
         listedOnMyHealthApplication: false,
         medicalDisclaimerImageLink: 'www.one2bindthem.com/assets/medicalDisclaimer.jpeg',
         monitizationExplanation: 'n/a',
@@ -112,6 +113,7 @@ describe('validations', () => {
     centralizedBackendLog: 'non-existent',
     distributingAPIKeysToCustomers: false,
     exposeVeteranInformationToThirdParties: false,
+    is508Compliant: true,
     listedOnMyHealthApplication: false,
     monitizationExplanation: 'n/a',
     monitizedVeteranInformation: false,
@@ -147,6 +149,24 @@ describe('validations', () => {
     vulnerabilityManagement: 'golem',
     website: 'www.one2bindthem.com',
   };
+
+  describe('is508Compliant', () => {
+    it('is required', () => {
+      const payload = { ...defaultPayload, is508Compliant: undefined };
+
+      const result = productionSchema.validate(payload);
+
+      expect(result.error?.message).toEqual('"is508Compliant" is required');
+    });
+
+    it('is a boolean', () => {
+      const payload = { ...defaultPayload, is508Compliant: 123456 };
+
+      const result = productionSchema.validate(payload);
+
+      expect(result.error?.message).toEqual('"is508Compliant" must be a boolean');
+    });
+  });
 
   describe('primaryContact', () => {
     it('is required', () => {

--- a/routes/ProductionRequest.ts
+++ b/routes/ProductionRequest.ts
@@ -18,6 +18,7 @@ export const productionSchema = Joi.object()
     centralizedBackendLog: Joi.string(),
     distributingAPIKeysToCustomers: Joi.boolean(),
     exposeVeteranInformationToThirdParties: Joi.boolean(),
+    is508Compliant: Joi.boolean().required(),
     listedOnMyHealthApplication: Joi.boolean(),
     monitizationExplanation: Joi.string(),
     monitizedVeteranInformation: Joi.boolean().required(),

--- a/services/GovDeliveryService.test.ts
+++ b/services/GovDeliveryService.test.ts
@@ -186,6 +186,7 @@ describe('GovDeliveryService', () => {
           centralizedBackendLog: 'non-existent',
           distributingAPIKeysToCustomers: false,
           exposeVeteranInformationToThirdParties: false, // eslint-disable-line id-length
+          is508Compliant: true,
           listedOnMyHealthApplication: false,
           medicalDisclaimerImageLink: 'www.one2bindthem.com/assets/disclaimer',
           monitizationExplanation: 'n/a',

--- a/templates/production.ts
+++ b/templates/production.ts
@@ -145,7 +145,19 @@ export const PRODUCTION_ACCESS_CONSUMER_TEMPLATE = `
 </div>
 `;
 
-export const PRODUCTION_ACCESS_SUPPORT_TEMPLATE = `<h2>Basic Information</h2>
+export const PRODUCTION_ACCESS_SUPPORT_TEMPLATE = `
+<h2>Verification</h2>
+<ul>
+  <li>
+    <div>
+      <strong>
+        <div>Application is 508 Compliant:</div>
+      </strong>
+      <div>{{is508Compliant}}</div>
+    </div>
+  </li>
+</ul>
+<h2>Basic Information</h2>
 <ul>
   <li>
     <div>

--- a/types/ProductionAccess.ts
+++ b/types/ProductionAccess.ts
@@ -42,4 +42,5 @@ export interface ProductionAccessSupportEmail {
   appImageLink: string;
   patientWaitTimeImageLink: string;
   medicalDisclaimerImageLink: string;
+  is508Compliant: boolean;
 }


### PR DESCRIPTION
This PR handles the backend portion of [API-9873](https://vajira.max.gov/browse/API-9873). With this PR, the production access form endpoint now accepts the answer to the 508 compliance question and adds the answer to the email. 